### PR TITLE
Bruk vanlig fødselsnummer for norske familier i testdata

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/kontrakter/søknad/testdata/SøknadTestdata.kt
+++ b/src/main/kotlin/no/nav/familie/ks/kontrakter/søknad/testdata/SøknadTestdata.kt
@@ -9,13 +9,13 @@ class SøknadTestdata {
         val mapper: ObjectMapper = ObjectMapper()
 
         const val morAktørId = "1300000000001"
-        const val morPersonident = "00000000001"
+        const val morPersonident = "12345678901"
 
         const val farAktørId = "1300000000002"
-        const val farPersonident = "00000000002"
+        const val farPersonident = "12345678911"
 
         const val barnAktørId = "1300000000003"
-        const val barnPersonident = "00000000003"
+        const val barnPersonident = "00000000033"
 
         const val utenlandskBarnAktørId = "1300000000004"
         const val utenlandskBarnPersonident = "00000000004"

--- a/src/main/resources/søknader/SøknadNorskFamilieGradertBarnehageplass.json
+++ b/src/main/resources/søknader/SøknadNorskFamilieGradertBarnehageplass.json
@@ -1,6 +1,6 @@
 {
   "innsendtTidspunkt": "2019-10-02T10:17:41.797Z",
-  "oppgittAnnenPartFødselsnummer": "00000000002",
+  "oppgittAnnenPartFødselsnummer": "12345678911",
   "oppgittErklæring": {
     "isBarnINorgeNeste12Måneder": true,
     "isBarnetHjemmeværendeOgIkkeAdoptert": true,
@@ -14,7 +14,7 @@
         "barnehageDato": "2019-01-01",
         "barnehageKommune": "Oslo",
         "barnehageStatus": "skalBegynneIBarnehage",
-        "fødselsnummer": "00000000003",
+        "fødselsnummer": "00000000033",
         "vedlegg": []
       }
     ],
@@ -25,7 +25,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000001",
+        "fødselsnummer": "12345678901",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -34,7 +34,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000002",
+        "fødselsnummer": "12345678911",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -45,14 +45,14 @@
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000001"
+        "fødselsnummer": "12345678901"
       },
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000002"
+        "fødselsnummer": "12345678911"
       }
     ]
   },
-  "søkerFødselsnummer": "00000000001"
+  "søkerFødselsnummer": "12345678901"
 }

--- a/src/main/resources/søknader/SøknadNorskFamilieMedBarnehageplass.json
+++ b/src/main/resources/søknader/SøknadNorskFamilieMedBarnehageplass.json
@@ -1,6 +1,6 @@
 {
   "innsendtTidspunkt": "2019-10-02T10:17:41.797Z",
-  "oppgittAnnenPartFødselsnummer": "00000000002",
+  "oppgittAnnenPartFødselsnummer": "12345678911",
   "oppgittErklæring": {
     "isBarnINorgeNeste12Måneder": true,
     "isBarnetHjemmeværendeOgIkkeAdoptert": true,
@@ -14,7 +14,7 @@
         "barnehageDato": "2020-01-01",
         "barnehageKommune": "Oslo",
         "barnehageStatus": "harBarnehageplass",
-        "fødselsnummer": "00000000003",
+        "fødselsnummer": "00000000033",
         "vedlegg": []
       }
     ],
@@ -25,7 +25,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000001",
+        "fødselsnummer": "12345678901",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -34,7 +34,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000002",
+        "fødselsnummer": "12345678911",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -45,14 +45,14 @@
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000001"
+        "fødselsnummer": "12345678901"
       },
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000002"
+        "fødselsnummer": "12345678911"
       }
     ]
   },
-  "søkerFødselsnummer": "00000000001"
+  "søkerFødselsnummer": "12345678901"
 }

--- a/src/main/resources/søknader/SøknadNorskFamilieUtenAnnenPartOgUtenBarnehageplass.json
+++ b/src/main/resources/søknader/SøknadNorskFamilieUtenAnnenPartOgUtenBarnehageplass.json
@@ -14,7 +14,7 @@
         "barnehageDato": "",
         "barnehageKommune": "",
         "barnehageStatus": "garIkkeIBarnehage",
-        "fødselsnummer": "00000000003",
+        "fødselsnummer": "00000000033",
         "navn": "Jakob Jakobsen",
         "vedlegg": []
       }
@@ -26,7 +26,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000001",
+        "fødselsnummer": "12345678901",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -37,10 +37,10 @@
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000001"
+        "fødselsnummer": "12345678901"
       }
     ]
   },
   "språk": "nb",
-  "søkerFødselsnummer": "00000000001"
+  "søkerFødselsnummer": "12345678901"
 }

--- a/src/main/resources/søknader/SøknadNorskFamilieUtenBarnehageplass.json
+++ b/src/main/resources/søknader/SøknadNorskFamilieUtenBarnehageplass.json
@@ -1,6 +1,6 @@
 {
   "innsendtTidspunkt": "2019-10-02T10:17:41.797Z",
-  "oppgittAnnenPartFødselsnummer": "00000000002",
+  "oppgittAnnenPartFødselsnummer": "12345678911",
   "oppgittErklæring": {
     "isBarnINorgeNeste12Måneder": true,
     "isBarnetHjemmeværendeOgIkkeAdoptert": true,
@@ -14,7 +14,7 @@
         "barnehageDato": "",
         "barnehageKommune": "",
         "barnehageStatus": "garIkkeIBarnehage",
-        "fødselsnummer": "00000000003",
+        "fødselsnummer": "00000000033",
         "vedlegg": []
       }
     ],
@@ -25,7 +25,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000001",
+        "fødselsnummer": "12345678901",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -34,7 +34,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000002",
+        "fødselsnummer": "12345678911",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -45,14 +45,14 @@
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000001"
+        "fødselsnummer": "12345678901"
       },
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000002"
+        "fødselsnummer": "12345678911"
       }
     ]
   },
-  "søkerFødselsnummer": "00000000001"
+  "søkerFødselsnummer": "12345678901"
 }

--- a/src/main/resources/søknader/SøknadNorskFamilieUtenBarnehageplassFlerlinger.json
+++ b/src/main/resources/søknader/SøknadNorskFamilieUtenBarnehageplassFlerlinger.json
@@ -1,6 +1,6 @@
 {
   "innsendtTidspunkt": "2019-10-02T10:17:41.797Z",
-  "oppgittAnnenPartFødselsnummer": "00000000002",
+  "oppgittAnnenPartFødselsnummer": "12345678911",
   "oppgittErklæring": {
     "isBarnINorgeNeste12Måneder": true,
     "isBarnetHjemmeværendeOgIkkeAdoptert": true,
@@ -14,7 +14,7 @@
         "barnehageDato": "",
         "barnehageKommune": "",
         "barnehageStatus": "garIkkeIBarnehage",
-        "fødselsnummer": "00000000003",
+        "fødselsnummer": "00000000033",
         "navn": "Jakob Jakobsen",
         "vedlegg": []
       },
@@ -23,7 +23,7 @@
         "barnehageDato": "",
         "barnehageKommune": "",
         "barnehageStatus": "garIkkeIBarnehage",
-        "fødselsnummer": "00000000007",
+        "fødselsnummer": "00000000077",
         "navn": "Jakob Jakobsen",
         "vedlegg": []
       }
@@ -36,7 +36,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000001",
+        "fødselsnummer": "12345678901",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -45,7 +45,7 @@
       {
         "arbeidIUtlandet": "NEI",
         "arbeidIUtlandetForklaring": "",
-        "fødselsnummer": "00000000002",
+        "fødselsnummer": "12345678911",
         "kontantstøtteIUtlandet": "NEI",
         "kontantstøtteIUtlandetForklaring": "",
         "ytelseIUtlandet": "NEI",
@@ -56,15 +56,15 @@
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000001"
+        "fødselsnummer": "12345678901"
       },
       {
         "boddEllerJobbetINorgeMinstFemAar": "jaINorge",
         "boddEllerJobbetINorgeMinstFemAarForklaring": "",
-        "fødselsnummer": "00000000002"
+        "fødselsnummer": "12345678911"
       }
     ]
   },
   "språk": "nb",
-  "søkerFødselsnummer": "00000000001"
+  "søkerFødselsnummer": "12345678901"
 }


### PR DESCRIPTION
De gamle fødselsnumrene ligner på FDAT-identer. Dette gjør at testene i ks-sak ikke lenger kjører når ks-sak spesialhåndterer FDAT. 